### PR TITLE
시나리오 별 동시성 이슈 분석 및 제어 방안

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
 
 	// Redis
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+	implementation("org.redisson:redisson-spring-boot-starter:3.43.0")
 	implementation("com.fasterxml.jackson.core:jackson-databind")
 
 }

--- a/src/main/java/kr/hhplus/be/server/ServerApplication.java
+++ b/src/main/java/kr/hhplus/be/server/ServerApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
-@EnableRetry
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/hhplus/be/server/common/config/RetryConfig.java
+++ b/src/main/java/kr/hhplus/be/server/common/config/RetryConfig.java
@@ -1,0 +1,42 @@
+package kr.hhplus.be.server.common.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+@Slf4j
+public class RetryConfig {
+
+    @Bean
+    public RetryListener retryListener() {
+        return new RetryListener() {
+            @Override
+            public <T, E extends Throwable> void onError(
+                    RetryContext context, RetryCallback<T, E> callback, Throwable throwable
+            ) {
+                log.error("Retryable {}회 실패: {}", context.getRetryCount(), throwable.getMessage());
+            }
+
+            @Override
+            public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
+                log.info("Retryable 시작");
+                return true;
+            }
+
+            @Override
+            public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
+                if (throwable == null) {
+                    log.info("Retryable 성공");
+                } else {
+                    log.warn("Retryable 예외 발생: {}", throwable.getMessage());
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/coupon/infra/CouponJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/infra/CouponJpaRepository.java
@@ -1,17 +1,20 @@
 package kr.hhplus.be.server.coupon.infra;
 
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import kr.hhplus.be.server.coupon.domain.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
 
-    @Query("SELECT c FROM Coupon c WHERE c.id = :couponId")
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")})
+    @Query("SELECT c FROM Coupon c WHERE c.id = :couponId")
     Optional<Coupon> findByIdForUpdate(@Param("couponId") Long couponId);
 }

--- a/src/main/java/kr/hhplus/be/server/coupon/infra/UserCouponJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/infra/UserCouponJpaRepository.java
@@ -1,12 +1,12 @@
 package kr.hhplus.be.server.coupon.infra;
 
-import aj.org.objectweb.asm.commons.Remapper;
 import jakarta.persistence.LockModeType;
-import kr.hhplus.be.server.coupon.domain.Coupon;
+import jakarta.persistence.QueryHint;
 import kr.hhplus.be.server.coupon.domain.UserCoupon;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -22,6 +22,7 @@ public interface UserCouponJpaRepository extends JpaRepository<UserCoupon, Long>
                                                                         @Param("couponId") Long couponId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")})
     @Query("SELECT uc FROM UserCoupon uc WHERE uc.couponId = :couponId AND uc.userId = :userId")
     Optional<UserCoupon> findByCouponIdAndUserIdForUpdate(Long couponId, Long userId);
 }

--- a/src/main/java/kr/hhplus/be/server/order/application/OrderFacade.java
+++ b/src/main/java/kr/hhplus/be/server/order/application/OrderFacade.java
@@ -6,11 +6,14 @@ import kr.hhplus.be.server.product.domain.ProductService;
 import kr.hhplus.be.server.user.domain.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,31 +26,50 @@ public class OrderFacade {
     private final ProductService productService;
     private final OrderItemDataMapper orderItemDataMapper;
     private final OrderInfoMapper orderInfoMapper;
+    private final RedissonClient redissonClient;
 
     @Transactional
     public OrderInfo createOrder(OrderCommand command) {
+        String lockKey = "lock:user:" + command.userId();
+        RLock lock = redissonClient.getLock(lockKey);
 
-        userService.getUser(command.userId());
+        boolean isLocked = false;
+        try {
 
-        Map<Long, Long> productQuantities = command.productOrderCommands().stream()
-                .collect(Collectors.toMap(ProductOrderCommand::productId, ProductOrderCommand::quantity));
+            isLocked = lock.tryLock(0, 5, TimeUnit.SECONDS);
+            if (!isLocked) {
+                throw new IllegalStateException("동일 사용자는 동시에 여러 주문을 할 수 없습니다.");
+            }
 
-        List<Long> productIds = List.copyOf(productQuantities.keySet());
+            userService.getUser(command.userId());
 
-        List<OrderItemData> orderItemDataList = productService.findByIdForUpdate(productIds).stream()
-                .map(product -> orderItemDataMapper.toOrderItemData(
-                        product,
-                        productQuantities.get(product.getId())
-                ))
-                .collect(Collectors.toList());
+            Map<Long, Long> productQuantities = command.productOrderCommands().stream()
+                    .collect(Collectors.toMap(ProductOrderCommand::productId, ProductOrderCommand::quantity));
 
-        productService.deductStock(productQuantities);
+            List<Long> productIds = List.copyOf(productQuantities.keySet());
 
-        Order order = orderService.createOrder(command.userId(), orderItemDataList);
+            List<OrderItemData> orderItemDataList = productService.findByIdForUpdate(productIds).stream()
+                    .map(product -> orderItemDataMapper.toOrderItemData(
+                            product,
+                            productQuantities.get(product.getId())
+                    ))
+                    .collect(Collectors.toList());
 
-        List<OrderItemInfo> orderItemInfos = orderItemDataList.stream()
-                .map(orderInfoMapper::toOrderItemInfo)
-                .collect(Collectors.toList());
-        return orderInfoMapper.toOrderInfo(order, orderItemInfos);
+            productService.deductStock(productQuantities);
+
+            Order order = orderService.createOrder(command.userId(), orderItemDataList);
+
+            List<OrderItemInfo> orderItemInfos = orderItemDataList.stream()
+                    .map(orderInfoMapper::toOrderItemInfo)
+                    .collect(Collectors.toList());
+            return orderInfoMapper.toOrderInfo(order, orderItemInfos);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("주문 처리 중 interruptr 발생", e);
+        } finally {
+            if (isLocked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
     }
 }

--- a/src/main/java/kr/hhplus/be/server/payment/application/PaymentFacade.java
+++ b/src/main/java/kr/hhplus/be/server/payment/application/PaymentFacade.java
@@ -12,8 +12,12 @@ import kr.hhplus.be.server.user.domain.User;
 import kr.hhplus.be.server.user.domain.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -28,48 +32,55 @@ public class PaymentFacade {
     private final OrderDataMapper orderDataMapper;
     private final PaymentInfoMapper paymentInfoMapper;
     private final ExternalDataService externalDataService;
+    private final RedissonClient redissonClient;
 
     @Transactional
     public PaymentInfo createPayment(PaymentCommand command) {
-        log.info("Start Payment Process for User: {}, Order: {}", command.userId(), command.orderId());
+        String lockKey = "lock:payment:order:" + command.orderId();
+        RLock lock = redissonClient.getLock(lockKey);
 
-        userService.getUser(command.userId());
-        log.info("User validated: {}", command.userId());
+        boolean isLocked = false;
+        try {
+            isLocked = lock.tryLock(0, 5, TimeUnit.SECONDS);
+            if (!isLocked) {
+                throw new IllegalStateException("동일 주문에 대해 동시에 여러 결제를 할 수 없습니다.");
+            }
 
-        Order order = orderService.getOrder(command.orderId());
-        log.info("Order validated: {}, Status: {}", command.orderId(), order.getStatus());
+            userService.getUser(command.userId());
 
-        Long discountAmount = 0L;
-        if (command.couponId() != null) {
-            log.info("Trying to use coupon for User: {}, Coupon: {}", command.userId(), command.couponId());
-            Coupon coupon = couponService.useCoupon(command.userId(), command.couponId());
-            discountAmount = coupon.calculateDiscount(command.orderPrice());
-            log.info("Coupon used successfully. Discount: {}", discountAmount);
+            Order order = orderService.getOrder(command.orderId());
+
+            Long discountAmount = 0L;
+            if (command.couponId() != null) {
+                Coupon coupon = couponService.useCoupon(command.userId(), command.couponId());
+                discountAmount = coupon.calculateDiscount(command.orderPrice());
+            }
+
+            Long finalPrice = command.orderPrice() - discountAmount;
+
+            Point point = pointService.findPointForUpdate(command.userId());
+            pointService.deductPoint(point, finalPrice);
+
+            Payment payment = paymentService.createPayment(
+                    command.orderId(),
+                    command.orderPrice(),
+                    finalPrice,
+                    command.couponId()
+            );
+
+            orderService.completeOrder(command.orderId());
+
+            OrderData orderData = orderDataMapper.toOrderData(order);
+            externalDataService.sendOrderData(orderData);
+
+            return paymentInfoMapper.toPaymentInfo(payment);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("결제 처리 중 interrupt 발생", e);
+        } finally {
+            if (isLocked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
         }
-
-        Long finalPrice = command.orderPrice() - discountAmount;
-        log.info("Final price calculated: {}", finalPrice);
-
-        Point point = pointService.findPointForUpdate(command.userId());
-        log.info("Point deducted 전 테스트 for User: {}, Remaining Points: {}", command.userId(), point.getPoint());
-        pointService.deductPoint(point, finalPrice);
-        log.info("Point deducted for User: {}, Remaining Points: {}", command.userId(), point.getPoint());
-
-        Payment payment = paymentService.createPayment(
-                command.orderId(),
-                command.orderPrice(),
-                finalPrice,
-                command.couponId()
-        );
-        log.info("Payment created: {}", payment.getId());
-
-        orderService.completeOrder(command.orderId());
-        log.info("Order completed: {}", command.orderId());
-
-        OrderData orderData = orderDataMapper.toOrderData(order);
-        externalDataService.sendOrderData(orderData);
-        log.info("Order data sent to external service: {}", order.getId());
-
-        return paymentInfoMapper.toPaymentInfo(payment);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/point/domain/Point.java
+++ b/src/main/java/kr/hhplus/be/server/point/domain/Point.java
@@ -27,6 +27,10 @@ public class Point extends BaseEntity {
     @Column(nullable = false)
     private Long point;
 
+    @Version
+    @Column(name = "version", nullable = false)
+    private Long version;
+
     @Builder
     public Point(Long id, Long userId, Long point) {
         this.id = id;

--- a/src/main/java/kr/hhplus/be/server/point/domain/Point.java
+++ b/src/main/java/kr/hhplus/be/server/point/domain/Point.java
@@ -27,10 +27,6 @@ public class Point extends BaseEntity {
     @Column(nullable = false)
     private Long point;
 
-    @Version
-    @Column(name = "version", nullable = false)
-    private Long version;
-
     @Builder
     public Point(Long id, Long userId, Long point) {
         this.id = id;

--- a/src/main/java/kr/hhplus/be/server/point/domain/PointService.java
+++ b/src/main/java/kr/hhplus/be/server/point/domain/PointService.java
@@ -26,16 +26,11 @@ public class PointService {
                         .build()));
     }
 
-    @Retryable(
-            value = {OptimisticLockException.class, ObjectOptimisticLockingFailureException.class},
-            maxAttempts = 5, // 재시도 횟수
-            backoff = @Backoff(delay = 100, multiplier = 2) // 지수 백오프 적용
-    )
     @Transactional
     public Point chargePoint(Long userId, Long amount) {
         Point.validatePoint(amount);
 
-        Point point = pointRepository.findByUserId(userId)
+        Point point = pointRepository.findByUserIdForUpdate(userId)
                 .orElseThrow(() -> new NoSuchElementException(ErrorCode.POINT_NOT_FOUND_CODE));
 
         point.charge(amount);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,12 @@ spring:
       host: localhost
       port: 6379
 
+redisson:
+  singleServerConfig:
+    address: "redis://localhost:6379"
+    connectionPoolSize: 10
+    connectionMinimumIdleSize: 2
+
 logging:
   level:
     root: INFO

--- a/src/test/java/kr/hhplus/be/server/coupon/CouponConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/coupon/CouponConcurrencyTest.java
@@ -52,7 +52,7 @@ public class CouponConcurrencyTest {
 
     @Test
     void 여러_사용자가_동시에_쿠폰을_발급해도_최대_사용_가능_수를_초과하지_않는다() throws InterruptedException {
-        int threadCount = 10; // 동시 요청 수
+        int threadCount = 150; // 동시 요청 수
         int maxCoupons = usageLimit.intValue(); // 최대 쿠폰 발급 수
 
         List<Long> userIds = new ArrayList<>();
@@ -106,7 +106,7 @@ public class CouponConcurrencyTest {
 
     @Test
     void 동일_사용자가_동일_쿠폰을_여러_번_요청해도_중복_발급되지_않는다() throws InterruptedException {
-        int requestCount = 10;
+        int requestCount = 100;
         ExecutorService executorService = Executors.newFixedThreadPool(requestCount);
         List<Throwable> exceptions = new ArrayList<>();
         List<Future<UserCoupon>> futures = new ArrayList<>();

--- a/src/test/java/kr/hhplus/be/server/point/PointConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/point/PointConcurrencyTest.java
@@ -49,7 +49,7 @@ public class PointConcurrencyTest {
 
     @Test
     void 한_사용자가_동시에_포인트를_충전해도_포인트가_정상적으로_누적된다() throws InterruptedException, ExecutionException {
-        int threadCount = 10;
+        int threadCount = 100;
         Long chargeAmountPerThread = 1000L;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         List<Callable<Void>> tasks = new ArrayList<>();

--- a/src/test/java/kr/hhplus/be/server/point/PointServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/point/PointServiceTest.java
@@ -89,13 +89,16 @@ public class PointServiceTest {
         Point point = new Point(1L, 1L, 5_000L);
 
         when(pointRepository.findByUserIdForUpdate(userId)).thenReturn(Optional.of(point));
+        when(pointRepository.save(point)).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
-        Point result = pointService.chargePoint(userId, chargeAmount);
+        pointService.chargePoint(point.getUserId(), chargeAmount);
 
         // Then
-        assertEquals(8_000L, result.getPoint());
-        assertEquals(userId, result.getUserId());
+        verify(pointRepository).save(point);
+        Point updatedPoint = pointRepository.findByUserIdForUpdate(userId).orElseThrow();
+        assertEquals(8_000L, updatedPoint.getPoint());
+        assertEquals(userId, updatedPoint.getUserId());
     }
 
     @Test


### PR DESCRIPTION
### **`STEP 11`**

- 나의 시나리오에서 발생할 수 있는 동시성 이슈에 대해 파악하고 가능한 동시성 제어 방식들을 도입해보고 
각각의 장단점을 파악한 내용을 정리 제출
   - 구현의 복잡도, 성능, 효율성 등

### **`STEP 12`**

- **DB Lock 을 활용한 동시성 제어 방식** 에서 해당 비즈니스 로직에서 적합하다고 판단하여 차용한 동시성 제어 방식을 구현하여 비즈니스 로직에 적용하고, 통합테스트 등으로 이를 검증하는 코드 작성 및 제출

## 동시성 이슈와 제어 방식 분석

<details>
<summary>MySQL 환경에서의 동시성 관리</summary>

### MySQL에서의 동시성 관리 개요
MySQL 환경에서 InnoDB 스토리지 엔진을 사용하고 있으며,  
기본 격리 수준인 REPEATABLE READ와 자동 적용되는 MVCC를 통해 동시성 문제를 효과적으로 방지한다.

    • Dirty Read : 한 트랜잭션이 아직 커밋되지 않은 다른 트랜잭션의 변경 내용을 읽는 현상
    • Non-repeatable Read : 동일한 트랜잭션 내에서 같은 쿼리를 두 번 실행했을 때, 두 번의 결과가 다른 현상
    • Phantom Read : 한 트랜잭션이 데이터를 읽은 후, 다른 트랜잭션이 해당 범위에 새로운 데이터를 삽입하여 첫 트랜잭션이 다시 데이터를 읽을 때 새로운 행이 나타나는 현상

### MVCC(Multi-Version Concurrency Control)의 역할
InnoDB는 MVCC를 통해 각 트랜잭션이 데이터의 특정 시점(snapshot)을 기준으로 작업을 수행하게 하여, 읽기 작업과 쓰기 작업이 서로 간섭하지 않도록 한다. 이를 통해 Dirty Read, Non-repeatable Read, Phantom Read와 같은 동시성 이슈를 효과적으로 방지할 수 있다.

### 내 환경에서 발생할 수 있는 동시성 이슈
	• 교착 상태(Deadlock) : 두 개 이상의 트랜잭션이 서로가 필요로 하는 자원을 점유한 채로 무한 대기 상태에 빠지는 문제
	• 락 경합(Lock Contention) : 여러 트랜잭션이 동일한 자원에 대해 락을 요청하면서 대기 시간이 길어지는 현상
	• 락 대기 시간 증가(Increased Lock Wait Time) : 트랜잭션이 락을 획득하지 못해 대기 시간이 길어지는 상황으로, 전체 시스템 성능 저하를 초래할 수 있음
</details>

<details>
<summary>서버 환경, 동시성 제어 방식</summary>
<br>

- **서버 환경** : 단일 서버, 단일 데이터베이스  
- **동시성 제어 방식** : 데이터베이스의 락 메커니즘(비관적 락, 낙관적 락)을 활용하여 동시성 문제를 제어
- **현재 동시성 제어 방식** : 포인트 충전, 쿠폰 발급, 주문, 결제 모두 비관적 락 (+배타 락) 사용
- **제어 방식 비교 대상** : 시나리오별 낙관적 락 적용 가능성 검토 후 적용 시 성능, 효율성, 코드 복잡도 비교
> 확장성을 고려한다면 분산 환경(다중 서버, 데이터베이스 샤딩 등)에서의 락 메커니즘(예: Redis 분산 락)을 도입할 수 있지만 
  이번 과제는 데이터베이스 락 메커니즘에 대해 초점을 두었습니다..
</details>


<details>
<summary>공유 락, 배타 락</summary>
<br>
현재 시나리오에서 총 4가지 동시성 시나리오 모두 데이터를 SELECT -> UPDATE한다.   

데이터 변경 시점을 안전하게 제어하기 위해 SELECT FOR UPDATE(Exclusive Lock)를 사용한다.

- 배타적 락 (Exclusive Lock)  
  `SELECT FOR UPDATE`는 해당 로우(혹은 인덱스 레인지)에 배타적 락을 걸어서 트랜잭션 안에서 SELECT와 UPDATE를 함께 수행할 수 있게 보호함.  
  락이 걸린 동안 다른 트랜잭션은 해당 데이터를 수정하거나 삭제할 수 없고, 락 해제까지 대기해야 함.  
  **읽기와 쓰기가 같은 트랜잭션 안에서 이루어지는 경우**에 적합함.

- 공유 락 (Shared Lock)  
  `SELECT ... LOCK IN SHARE MODE`는 여러 트랜잭션이 동시에 데이터를 읽을 수 있게 허용함.  
  하지만 데이터를 읽는 동안 다른 트랜잭션이 해당 데이터를 수정하거나 삭제할 수 없게 제어함.  
  **읽기와 쓰기가 다른 트랜잭션에서 이루어지는 경우**에 적합하며, 읽기 전용 시나리오나 동시 읽기 작업을 높이고자 할 때 사용됨.

> 4가지 동시성 시나리오 모두 데이터를 변경하는 작업이 요구사항의 핵심이며, 변경이 겹쳐서는 안 되므로 공유락은 고려 대상이 아님

</details>


<details>
<summary>비관적 락, 낙관적 락</summary>

| 항목              | 비관적 락                    | 낙관적 락                      |
|-------------------|------------------------------|--------------------------------|
| 동작 방식         | `SELECT FOR UPDATE`로 행 잠금 | `@Version`으로 충돌 여부 검사  |
| 충돌 시 처리      | 충돌 차단, 즉시 대기          | 충돌 감지, 예외 발생 → 재시도  |
| 장점              | 충돌 완전 방지, 안정적 처리    | 락 비용 최소, 병렬 처리 유리    |
| 단점              | 락 대기로 성능 저하 가능       | 충돌 시 재시도로 인한 성능 저하 |

</details>


<details>
<summary>포인트 충전</summary>

## 개요
- **개인 사용자 기준 포인트 충전** 기능
  - `userId`로 데이터를 조회·업데이트하므로, 서로 다른 사용자가 동일 데이터를 건드릴 가능성은 낮음
  - 동일 사용자의 중복 요청(예: 연속 클릭, 네트워크 지연)은 발생 가능성이 낮고, 빈번하지 않으나 동시성 이슈가 있음
  - 충돌 방지는 프론트엔드(버튼 비활성화 등)에서 일부 완화 가능하지만 완벽하지 않음

## 비관적 락(Pessimistic Lock) 사용 현황

![포인트 충전 - 기본로직](https://github.com/user-attachments/assets/ac1bc1d2-792b-44b7-a517-b22ad519819c)

- **동작 원리**: `SELECT FOR UPDATE`를 통해 DB가 행(Row)을 잠금 → 트랜잭션이 완료될 때까지 다른 쓰기 작업 차단
- **장점**  
  - 충돌을 미연에 방지하며, 데이터 무결성을 확실히 보장  
  - 충돌로 인한 예외가 없으므로 트랜잭션 로직이 단순하고 안정적  
- **단점**  
  - 불필요한 락으로 인해 DB 자원을 독점할 가능성  
  - 동시 요청이 많아지면 락 대기로 인한 성능 저하 발생 가능

## 낙관적 락(Optimistic Lock) 사용 검토
- 포인트 충전은 동시성 이슈가 빈번하지 않을 것으로 판단됨  
- 충전 중 동시성 이슈 발생 시,  **전부 성공**을 보장하려고 함
- 낙관적 락과 재시도 로직을 결합하여 DB 성능을 최적화하고, 전체 트랜잭션이 성공하도록 시도 - 773a21b

- **동작 원리**: 엔티티의 `@Version` 필드를 이용, 트랜잭션 종료 시점에서 버전 충돌을 감지  
  - 충돌 발생 시 OptimisticLockException 발생 → 재시도 로직(@Retryable) 필요 (또는 try-catch로 수동 구현 가능)
  - 충돌이 없으면 DB 락 없이 빠르게 처리
- **장점**  
  - 충돌이 적은 환경에서 **락 비용 0**에 가까워 높은 병렬 처리 가능    
  - 읽기 비중이 높거나 동시 충돌이 희박한 시나리오에 적합  
- **단점**  
  - 충돌 시 예외 발생 및 재시도 필요 → 빈번하면 오히려 성능 저하   
  - 재시도 로직 구현으로 인해 코드 복잡도 상승


## 동시성 테스트 결과 

[포인트 충전 동시성 테스트 코드](https://github.com/dhgudtmxhs/hhplus-ecommerce/blob/main/src/test/java/kr/hhplus/be/server/point/PointConcurrencyTest.java)

<details>
<summary>비관적 락 - 스레드 10개</summary>

#### 시작

![포인트충전-비관적락-스레드10-시작](https://github.com/user-attachments/assets/e0b1c62a-be90-408b-ad66-e6560fe8baed)

#### 종료

![포인트충전-비관적락-스레드10-종료](https://github.com/user-attachments/assets/662d0815-d076-4938-9775-56c1975b332c)

 - 경과 시간 : 760ms - 594ms = 166ms
 - 2번 째 테스트 경과시간 : 978ms - 799ms = 179ms 
 - 3번 째 테스트 경과시간 : 546ms - 346ms = 200ms

</details>

<details>
<summary>낙관적 락 - 스레드 10개, 재시도 3번</summary>

#### 시작

![포인트충전-낙관적락-스레드10-시작](https://github.com/user-attachments/assets/0df37dc1-cbaf-4068-a132-e4446d40465a)

#### 종료

![포인트충전-낙관적락-스레드10-종료](https://github.com/user-attachments/assets/5651db21-3d9f-4745-a8f7-e3f79e47226f)

 - 경과 시간 : 831ms - 305ms = 526ms
 - 2번 째 테스트 경과시간 : 55.278ms - 54.266ms = 1012ms 
 - 3번 째 테스트 경과시간 : 48.473ms - 47.874ms = 599ms

</details>

<details>
<summary>비관적 락 - 스레드 100개</summary>

#### 시작

![포인트충전-비관적락-스레드100-시작](https://github.com/user-attachments/assets/57dbf8c0-c865-4052-91a0-a1478123aa6e)

#### 종료

![포인트충전-비관적락-스레드100-종료](https://github.com/user-attachments/assets/e1d73994-dd1c-4334-9fae-35d075c87c88)

 - 경과 시간 : 58.007ms - 56.903ms = 1104ms
 - 2번 째 테스트 경과시간 : 36.151ms - 35.119ms = 1032ms 
 - 3번 째 테스트 경과시간 : 09.873ms - 08.760ms = 1113ms

</details>

<details>
<summary>낙관적 락 - 스레드 100개, 재시도 5번</summary>

#### 오류

![포인트충전-낙관적락-스레드100-재시도5-오류](https://github.com/user-attachments/assets/66e0dc67-43bd-4fc9-9c8a-bb473da55df2)

 - 많은 동시성으로 인해 5번의 재시도로는 예외 발생

</details>

<details>
<summary>낙관적 락 - 스레드 100개, 재시도 10번</summary>

#### 시작

![포인트충전-낙관적락-스레드100-재시도10-시작](https://github.com/user-attachments/assets/3d3fd97d-dae2-430f-96be-96c5bcf5d948)

#### 종료

![포인트충전-낙관적락-스레드100-재시도10-종료](https://github.com/user-attachments/assets/7c5ecbe3-e615-4e28-aa49-6e1f3b361219)

 - 경과 시간 : 31.849ms - 24.081ms = 7768ms
 - 2번 째 테스트 경과시간 : 35.389ms - 27.948ms = 7741ms
 - 3번 째 테스트 경과시간 : 53.188ms - 39.446ms = 13742ms
> 테스트 마다 Retry 횟수가 다르게 실패함 -> 동시성 수에 대해 재시도  횟수를 예상할수 없음, 횟수를 크게 잡는다면 성능저하 
</details>

### 분석 요약
 - 낙관적 락과 재시도 로직은 비관적 락에 비해 구현 복잡도가 다소 높지만, 두 방식 모두 큰 어려움 없이 구현 가능한 수준임

- **스레드 10개**  
  - 낙관적 락에 재시도 로직을 적용했는데 비관적 락보다 성능이 떨어짐

- **스레드 100개**  
  - 재시도 횟수 5번으로는 충돌 처리가 안 됨  
  - 재시도 횟수 10번으로 성공은 했지만 처리 시간이 늘어나서 성능 저하 발생, 테스트마다 재시도 횟수가 다름
  - 낙관적 락으로는 100% 성공 보장이 어렵다고 판단

### 결론
- **포인트 충전 요구사항**  
  - 트랜잭션 실패 없이 **모두 성공**해야 함  
  - 충돌 가능성은 낮지만, 발생 시 데이터 불일치를 방지해야 함  

- **비관적 락**  
  - 안정적이고 충돌 가능성이 낮은 환경에 적합함  
  - 하지만 불필요한 락 대기로 성능 저하가 발생할 수 있음  

- **낙관적 락 + 재시도 로직**  
  - 충돌이 적은 환경에서는 성능이 더 좋음  
  - 하지만 충돌 시 재시도 로직이 성능을 저하시켜 비관적 락보다 느리고, 100% 성공 보장이 어려움  

> 포인트 충전은 **비관적 락**을 유지한다. - 33ff6c3
 
</details>


<details>
<summary>쿠폰 발급</summary>

## 개요
- **여러 사용자 기준 선착순 쿠폰 발급** 기능
  - 쿠폰 발급은 `couponId` 기준으로 데이터를 조회 및 업데이트
  - 여러 사용자가 동시에 동일한 쿠폰을 발급받으려 할 가능성이 존재
  - 자기 자신의 **중복 요청**(동일 쿠폰 발급 시도)과 **타인의 중복 발급**을 모두 방지

- **중복 발급 방지 로직**
  - **쿠폰 조회 및 락**: `couponId`로 쿠폰 데이터를 조회(`SELECT ... FOR UPDATE`)
  - **사용자 중복 발급 여부 확인 및 락**: `couponId`와 `userId`로 사용자 발급 기록 조회(`SELECT ... FOR UPDATE`)
  - **쿠폰 상태 갱신**: 쿠폰 사용 가능 수량 감소 등 상태 변경 로직 수행 (`coupon.issue()`)
  - **사용자 쿠폰 생성**: `UserCoupon` 엔티티 생성 및 저장하여 발급 완료
> 사용자 중복 발급 여부는 Entity 레벨에서 @UniqueConstraint로도 방지하도록 했지만, 
유연한 정책 관리와 동시성 제어를 위해 비즈니스 로직 내에서 중복 발급 방지 로직을 우선 처리할 수 있도록 함

## 비관적 락(Pessimistic Lock) 사용 현황

![쿠폰 발급 - 기본로직](https://github.com/user-attachments/assets/ccaedbb2-3b8f-4598-b314-5dacd12cfbcc)

- 쿠폰 정보와 사용자 중복 여부를 각각 비관적 락으로 조회하여 동시성 문제를 방지한다.

## 낙관적 락(Optimistic Lock) 사용 검토
  - 여러 사용자가 동일 쿠폰에 동시에 접근하는 경우, **충돌 발생 빈도가 높음**
  - 현재 비관적 락은 쿠폰 발급과 사용자 중복 확인 두 곳에서 사용되며, 낙관적 락을 도입할 경우 비관적 락을 사용한 2가지 부분 모두 변경이 필요
  - 선착순으로 발급해야하기 때문에 충돌이 발생하면 낙관적 락은 재시도 로직이 필요하며, 이는 트랜잭션 수행 시간을 늘리고 성능을 저하시킬 가능성이 큼
  -  포인트 충전에서 이미 확인했으므로 낙관적 락은 사용하지 않음

## 데드락 방지 방안

- **트랜잭션 범위 최소화**
  - 비관적 락을 사용하는 트랜잭션의 범위를 최소화하여 락이 점유되는 시간을 줄임
  - 예: 쿠폰 상태 갱신 및 사용자 쿠폰 생성 작업을 분리하여 필요 최소한의 락만 사용

- **락 순서 통일**
  - 락을 획득하는 순서를 통일하여 데드락 발생 가능성을 제거
  - 예: 항상 `couponId` → `userId` 순서로 락을 획득

- **타임아웃 설정**
  - `FOR UPDATE` 쿼리에 타임아웃 설정을 추가하여 데드락 발생 시 대기 시간을 제한
  - 예: `@QueryHint`를 활용해 락 타임아웃 적용

    ```java
    @Lock(LockModeType.PESSIMISTIC_WRITE)
    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")})
    Optional<Coupon> findByIdForUpdate(Long couponId);
    ```
> 현재 로직에서, 락 순서 통일을 하는게 가장 간단할 것이라 생각되어 다른 로직이 추가된다면 그렇게 적용하도록 함
혹시 모를 다른 로직의 위험에 대비하기 위해 QueryHints 로 데드락을 방지하는 로직을 고려


## 동시성 테스트 결과

[쿠폰 발급 동시성 테스트 코드](https://github.com/dhgudtmxhs/hhplus-ecommerce/blob/main/src/test/java/kr/hhplus/be/server/coupon/CouponConcurrencyTest.java)

<details>
<summary>비관적 락 - 스레드 100개</summary>

#### 시작

![쿠폰발급-비관적락-스레드100-시작](https://github.com/user-attachments/assets/eafd1725-5b95-4b7e-8bc2-76dd27c0fa14)

#### 종료

![쿠폰발급-비관적락-스레드100-종료](https://github.com/user-attachments/assets/6f8e1679-499c-4aeb-bc68-9a58fd973886)

 - 모든 스레드가 정상적으로 작업을 완료  
 - 쿠폰 발급이 중복되지 않았으며, 쿠폰이 설정된 수량만큼만 발급되고 나머지는 롤백된 것을 확인  
 - 데드락 발생하지 않음: 여러 번 재시도해도 동일한 결과  

</details>

<details>
<summary>비관적 락 - 스레드 150개</summary>

#### 시작

![쿠폰발급-비관적락-스레드150-시작](https://github.com/user-attachments/assets/e6bdfc03-8308-4169-800c-52912d655420)

#### 종료

![쿠폰발급-비관적락-스레드150-종료](https://github.com/user-attachments/assets/8d10140d-5d44-4ffc-a7a2-b0b465698ddb)

 - 스레드 100개와 결과 동일

</details>


### 요약
 
 - 현재 코드에서 동일 쿠폰에 대해 항상 쿠폰(Coupon)을 먼저 락을 잡고, 이후 사용자-쿠폰(UserCoupon)을 확인하는 순서를 지키고 있는 상황인데, **데드락이 발생할만한 반대 순서의 로직이 없다.**
 - 여러번의 100개 이상의 동시성 요청 테스트가 데드락 없이 정상 처리됨을 확인했다.
 - 따라서 현 로직을 변경할 필요는 없으며, 데드락 위험을 줄이기 위해서도 굳이 추가 작업(락 순서 변경 등)을 적용하지 않는다.
 - 향후 다른 로직에서 UserCoupon → Coupon 순서로 락을 잡을 일이 생기지 않도록 주의하고, 필요 시 트랜잭션 범위 최소화와 락 타임아웃 설정 등을 적용해 데드락 위험을 완화할 수 있다.

## 결론
- 비관적 락을 쿠폰 발급, 중복 조회에 적용한 것은 쿠폰 발급 시나리오에 적합한 선택
- 데드락 방지를 위해 트랜잭션 최소화, 락 순서 통일, 타임아웃 설정 등의 방안을 적용할 수 있다.
- 현재 로직은 단일 환경에서 성능과 안정성을 충분히 보장하지만, 예상치 못한 동시성 문제를 예방하고 안정성을 더욱 강화하기 위해 쿼리에 QueryHints를 추가한다. - 67714fa

</details>




<details>
<summary>주문</summary>

## 개요
- **여러 사용자 기준 주문 생성** 기능
  - 주문 생성 시 `userId` 기준으로 데이터를 조회 및 업데이트
  - 여러 사용자가 동시에 주문을 생성할 가능성이 존재 -> 재고 문제
  - 여러 사용자의 동시 주문 시 재고 차감을 방지

- **중복 주문(재고차감) 방지 로직**
  - **사용자 정보 조회**: `userId`로 사용자 정보를 조회
  - **상품 수량 확인 및 잠금**: `productId`로 상품 데이터를 잠금 (`SELECT ... FOR UPDATE`)
  - **주문 아이템 생성**: 각 상품의 주문 아이템 데이터 생성 (`orderItemDataMapper.toOrderItemData()`)
  - **상품 재고 차감**: 상품 재고를 차감 (`productService.deductStock()`)
  - **주문 생성**: 주문 데이터를 생성 및 저장 (`orderService.createOrder()`)
  - **주문 정보 반환**: 생성된 주문 정보를 반환 (`orderInfoMapper.toOrderInfo()`)

## 비관적 락(Pessimistic Lock) 사용 현황

![주문 - 기본로직(파사드)](https://github.com/user-attachments/assets/c5036012-8998-4b53-8a2e-6f8c271c8471)

- 상품 재고를 비관적 락으로 조회하여 동시 주문 시의 재고 차감 문제를 방지한다.

## 추가로 발생할만한 동시성 처리
- 하나의 주문은 하나의 요청에서 여러 상품을 포함할 수 있는 구조(장바구니 개념)로 되어 있음
- 현재 로직에서는 동일 사용자가 동시에 여러 요청을 보내는 경우가 비정상적인 상황으로 생각됨
- 이러한 경우는 사용자의 실수(예: 잘못된 중복 클릭 또는 API 호출)로 인해 발생할 가능성이 크며, 이를 방지하는 로직이 필요함
- 동일 사용자의 동시 주문은 불가능하도록 해야 함

   - 추후 분산 환경을 고려해 Redis로 사용자 id에 lock, 시간을 적용하여 동일 사용자의 동시 주문을 제어 - 80e7d27
   - 상품 재고 감소 비관적 락도 추후 Redis lock으로 통일하려고 함
   - 기존 테스트 로직 수정(사용자 1명 -> 여러 사용자), 동시 중복 테스트 - b483842, a026936, a7cfa86

## 낙관적 락(Optimistic Lock) 사용 검토
- 여러 사용자의 주문 접근은, 동시성이 발생할 확률이 높음
- 쿠폰 사용과 마찬가지로, 비관적 락을 사용하는 방식이 더 적합하다고 판단
- 충돌 발생 시 낙관적 락은 재시도 로직이 필요하며, 이는 트랜잭션 수행 시간을 늘리고 성능 저하를 초래할 가능성이 큼
- 포인트 충전에서 이미 확인했으므로 낙관적 락은 사용하지 않음

## 데드락 방지 방안
- 현재 **Redis 분산 락**(사용자 `userId` 기준)과 **비관적 락**(상품 `productId` 기준)을 함께 사용 중이나, 데드락이 발생하지 않음

  - Redis 락은 특정 사용자에 대해 동시에 하나의 주문만 처리되도록 보장
  - 비관적 락은 상품 재고 데이터를 안전하게 처리하도록 보장
- 추후 **비관적 락**도 **Redis 분산 락**으로 전환하여 분산 환경에서 락 관리의 일관성을 유지하려고 함

- **데드락이 발생하지 않는 이유**
  - Redis 락과 비관적 락은 서로 다른 자원에 대해 작동하며, 락 순서가 고정적임
  - 락이 해제되지 않는 상태로 대기하는 시나리오가 없도록 설계되어 있음

## 동시성 테스트 결과

[주문 동시성 테스트 코드(수정전)](https://github.com/dhgudtmxhs/hhplus-ecommerce/blob/main/src/test/java/kr/hhplus/be/server/order/OrderFacadeConcurrencyTest.java)

<details>
<summary>비관적 락 - 스레드 100 x 주문 10</summary>

#### 종료

![스크린샷 2025-01-23 오후 10 47 18](https://github.com/user-attachments/assets/3b8bd80b-2a41-4c47-826f-f65b7538d1bf)

 - 모든 스레드가 정상적으로 작업을 완료  
 - 재고 차감이 중복되지 않았으며, 재고가 0까지만 주문이 이루어지고 나머지는 롤백된 것을 확인  
 - 데드락 발생하지 않음: 여러 번 재시도해도 동일  

</details>
 
### 요약
- 현재 코드에서 **Redis 분산 락**(사용자 `userId` 기준)과 **비관적 락**(상품 `productId` 기준)을 함께 사용 중이며, 데드락이 발생하지 않음을 확인
- 항상 Redis 락을 먼저 잡고, 이후 비관적 락을 잡는 순서를 유지하여 데드락 위험이 없음
- 여러번의 스레드 100 x 주문 10 동시성 요청 테스트를 통해 모든 작업이 정상적으로 처리됨을 검증
- **재고 차감 로직**도 추후 분산환경을 적용하며 Redis 분산 락으로 전환하여 일관성을 유지할 예정
- 따라서 현 로직을 변경하거나 락 순서를 수정할 필요가 없음

### 결론
- 비관적 락과 Redis 락을 조합한 현재 로직은 쿠폰 발급 및 재고 차감 시나리오에 적합하며 안정성을 보장하지만, 분산 환경에서의 일관성을 위해 락의 통일성이 필요하다고 판단됨
- **데드락 방지를 위한 원칙**

  - 락 순서를 일관되게 유지하여 반대 순서의 락이 발생하지 않도록 주의
  - 트랜잭션 범위를 최소화하여 락 대기 시간을 줄이고 성능을 최적화
  - 추후 분산 환경을 고려하여 QueryHints는 추가하지 않으며, 전체 Redis 락 전환으로 안정성을 강화

</details>





<details>
<summary>결제</summary>

## 개요
- **개인 사용자 주문 완료 후 결제 처리** 기능
  - 주문이 완료된 후 결제 API 요청을 진행
  - 주문 단계에서는 동일 사용자의 동시 주문을 방지하기 위한 검증을 수행하지만, 결제 단계에서도 포인트 차감과 쿠폰 사용과 같은 작업에서 필요한 동시성 검증이 별도로 이루어져야 함
  - 결제 과정에서 포인트 차감과 쿠폰 사용 모두 **비관적 락**을 사용하여 데이터 무결성과 일관성을 유지
  - 결제 단계는 주문을 기반으로 동작하며, 중복 결제를 방지하고 데이터 일관성을 보장

- **중복 결제 방지 로직**
  - **사용자 정보 조회**: 사용자 정보를 조회 (`userService.getUser()`)
  - **주문 정보 확인**: 주문 정보를 조회하고 상태를 확인 (`orderService.getOrder()`)
  - **쿠폰 사용 및 잠금**: 
    - 쿠폰 데이터를 잠금 처리 (`couponService.useCoupon()` - SELECT ... FOR UPDATE)
    - 쿠폰을 사용하여 할인 금액을 계산 (`coupon.calculateDiscount()`)
  - **포인트 차감 및 잠금**: 
    - 포인트 데이터를 잠금 처리 (`pointService.findPointForUpdate()`)
    - 최종 결제 금액을 기준으로 포인트를 차감 (`pointService.deductPoint()`)
  - **결제 정보 생성**: 결제 데이터를 생성하고 저장 (`paymentService.createPayment()`)
  - **주문 상태 업데이트**: 주문의 상태를 '완료'로 변경 (`orderService.completeOrder()`)
  - **외부 서비스 연동**: 주문 데이터를 외부 서비스로 전송 (`externalDataService.sendOrderData()`)
  - **결제 정보 반환**: 생성된 결제 정보를 반환 (`paymentInfoMapper.toPaymentInfo()`)

## 비관적 락(Pessimistic Lock) 사용 현황

![결제 - 기본로직(파사드)](https://github.com/user-attachments/assets/b52764f9-1a7e-4bd5-be0d-4b672f209e57)

- 포인트 차감과 쿠폰 사용에 비관적 락을 적용하여 중복 결제와 데이터 불일치를 방지한다.

## 추가로 발생할만한 동시성 처리
- **동일 주문에 대한 동시 결제 시도**
  - 동일 주문에 대해 여러 결제 요청이 동시에 발생할 경우, 중복 결제를 방지하기 위한 추가적인 동시성 검증이 필요함
    - 주문 후 결제 API 호출이라 동시성이 낮아 보이지만 방지
  - `Redis`를 사용하여 특정 주문에 대한 분산 락을 적용, 동일 주문에 대한 동시 결제를 차단함 - dc0141f

## 낙관적 락(Optimistic Lock) 사용 검토
- **동일 주문 중복 요청 방지**
  - 현재 `Redis`를 사용한 분산 락으로 동일 주문에 대한 중복 결제를 효과적으로 방지하고 있음
  - 이러한 구조에서 비관적 락을 병행하여 사용 중이지만, **분산 락만으로도 충분히 중복 요청 차단이 가능**하다고 판단됨

- **낙관적 락으로 전환하지 않는 이유**
  - 낙관적 락은 충돌 가능성이 낮은 상황에서 성능상의 이점이 있지만, 충돌 발생 시 재시도 로직이 추가되어 복잡성이 증가할 수 있음
  - 현재 비관적 락과 분산 락을 함께 사용하여 안정성을 유지하고 있음
  - 모든 동시성 제어를 **분산 락으로 전환**하려고 함
  - 낙관적 락으로의 전환은 고려하지 않으며, 분산 락을 통한 안정성과 단순성을 유지하는 방향으로 진행

## 동시성 테스트 결과

[결제 동시성 테스트 코드](https://github.com/dhgudtmxhs/hhplus-ecommerce/blob/main/src/test/java/kr/hhplus/be/server/payment/PaymentFacadeConcurrencyTest.java)

<details>
<summary>비관적 락 - 스레드 10</summary>

#### 종료

![스크린샷 2025-01-24 오전 1 03 55](https://github.com/user-attachments/assets/7627b730-dccb-4815-b606-f275e0837dc3)

 - 모든 스레드가 정상적으로 작업을 완료  
 - 결제 동시성은 거의 일어나지 않으므로 스레드 10개로 테스트
 - 분산 락으로만 모든 중복 요청이 차단됨을 확인
 - 데드락 발생하지 않음: 여러 번 재시도해도 동일  
</details>

## 결론
- 현재 구조에서 **Redis 분산 락**과 **비관적 락**을 혼용하여 안정성을 확보하고 있음
- 테스트 결과, 분산 락만으로도 모든 중복 요청이 차단됨, 비관적 락이 없어도 동일한 안정성을 보장할 수 있음
- 분산 락을 사용한 구조는 데드락 발생 가능성이 없으며, 락 순서와 해제 타이밍을 일관되게 유지하여 안전하게 처리되고 있음
- 모든 락을 분산 락으로만 처리되도록 전환한다. 

</details>

## PR 설명

feat : 재시도 로깅을 위한 RetryConfig 추가 - 5778721
build : Redisson 설정 추가 - 14e440b

refactor : 포인트 충전 - 낙관적 락 사용을 위한 수정 - 773a21b 
refactor : 포인트 충전 - 비관적 락으로 재수정 - 33ff6c3

refactor : 쿠폰 발급 - 비관적 락 유지, QueryHint로 잠재적 데드락 방지 - 67714fa

refactor : 주문 - 한 사용자의 동일 주문 동시 요청 방지를 위한 Redis 락 적용 - 80e7d27
test : 주문 - 동시성 테스트 수정, 추가 : b483842 , a026936 , a7cfa86

refactor : 결제 - 동일 주문에 동시 결제 방지를 위한 Redis 락 적용 - dc0141f

## 리뷰 포인트
동시성 분석과 선택이 합당한 판단이었는지, 놓친 부분이 있는지 궁금합니다.
낙관적 락을 쓸때 충돌을 드물게 설정해도 재시도 로직이 있다면 비관적 락보다 느렸는데, 낙관적 락을 쓰는 의미를 잘 모르겠습니다.
재시도 로직 없이 낙관적 락을 적용한다면 그게 의미가 있는건지..? 궁금합니다.

## KPT

#### Keep
설날 주 공부하기

#### Problem
분산환경 적용 안해봄, 레디스를 제대로 사용 못했음 
주문 - 결제 로직이 부족한 것 같음

#### Try
Problem 공부하기
