### PR TITLE
부하 테스트 대상 시나리오 작성 / 부하 테스트 

### DIFF
--- a/src/main/java/kr/hhplus/be/server/point/infra/PointJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/point/infra/PointJpaRepository.java
@@ -1,10 +1,12 @@
 package kr.hhplus.be.server.point.infra;
 
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import kr.hhplus.be.server.point.domain.Point;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
@@ -14,5 +16,9 @@ public interface PointJpaRepository extends JpaRepository<Point, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Point p where p.userId = :userId")
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")})
     Optional<Point> findByUserIdForUpdate(@Param("userId") Long userId);
 }
+
+
+

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -46,7 +46,7 @@ SELECT n FROM numbers;
 INSERT INTO `user` (name)
 SELECT CONCAT('User ', n)
 FROM temp_numbers
-WHERE n <= 100;
+WHERE n <= 1000;
 
 DROP TEMPORARY TABLE IF EXISTS temp_numbers;
 

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -33,3 +33,22 @@ SELECT
 FROM temp_numbers;
 
 DROP TEMPORARY TABLE IF EXISTS temp_numbers;
+CREATE TEMPORARY TABLE temp_numbers (n INT PRIMARY KEY);
+
+INSERT INTO temp_numbers (n)
+WITH RECURSIVE numbers AS (
+    SELECT 1 AS n
+    UNION ALL
+    SELECT n + 1 FROM numbers WHERE n < 1000000
+)
+SELECT n FROM numbers;
+
+INSERT INTO `user` (name)
+SELECT CONCAT('User ', n)
+FROM temp_numbers
+WHERE n <= 100;
+
+DROP TEMPORARY TABLE IF EXISTS temp_numbers;
+
+INSERT INTO point (user_id, point)
+SELECT id, 0 FROM `user`;

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -1,5 +1,7 @@
 DROP TABLE IF EXISTS order_item;
 DROP TABLE IF EXISTS product;
+DROP TABLE IF EXISTS `user`;
+DROP TABLE IF EXISTS point;
 
 CREATE TABLE product (
                          id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -21,3 +23,20 @@ CREATE TABLE order_item (
                             updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                             INDEX idx_order_item_product_created (product_id, created_at, quantity)
 ) ENGINE=InnoDB;
+
+CREATE TABLE `user` (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        name VARCHAR(255) NOT NULL,
+                        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+CREATE TABLE point (
+                       id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                       user_id BIGINT NOT NULL UNIQUE,
+                       point BIGINT NOT NULL,
+                       created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                       updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                       CONSTRAINT fk_point_user FOREIGN KEY (user_id) REFERENCES `user`(id)
+) ENGINE=InnoDB;
+

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -1,7 +1,7 @@
 DROP TABLE IF EXISTS order_item;
 DROP TABLE IF EXISTS product;
-DROP TABLE IF EXISTS `user`;
 DROP TABLE IF EXISTS point;
+DROP TABLE IF EXISTS `user`;
 
 CREATE TABLE product (
                          id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -36,7 +36,6 @@ CREATE TABLE point (
                        user_id BIGINT NOT NULL UNIQUE,
                        point BIGINT NOT NULL,
                        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                       updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-                       CONSTRAINT fk_point_user FOREIGN KEY (user_id) REFERENCES `user`(id)
+                       updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB;
 

--- a/src/test/resources/k6/point-charge-test.js
+++ b/src/test/resources/k6/point-charge-test.js
@@ -12,7 +12,7 @@ export let options = {
     ],
 };
 
-const userIds = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+const userIds = Array.from({ length: 1000 }, (_, i) => i + 1);
 
 export default function () {
     const userId = userIds[Math.floor(Math.random() * userIds.length)];
@@ -21,6 +21,7 @@ export default function () {
         userId: userId,
         amount: 1000
     });
+
     const params = { headers: { 'Content-Type': 'application/json' } };
 
     let res = http.patch('http://localhost:8080/api/point/charge', payload, params);

--- a/src/test/resources/k6/point-charge-test.js
+++ b/src/test/resources/k6/point-charge-test.js
@@ -1,0 +1,34 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export let options = {
+    stages: [
+        { duration: '10s', target: 100 },
+        { duration: '10s', target: 300 },
+        { duration: '10s', target: 500 },
+        { duration: '40s', target: 1000 },
+        { duration: '10s', target: 100 },
+        { duration: '5s', target: 0 }
+    ],
+};
+
+const userIds = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+export default function () {
+    const userId = userIds[Math.floor(Math.random() * userIds.length)];
+
+    const payload = JSON.stringify({
+        userId: userId,
+        amount: 1000
+    });
+    const params = { headers: { 'Content-Type': 'application/json' } };
+
+    let res = http.patch('http://localhost:8080/api/point/charge', payload, params);
+
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+        'response time < 2s': (r) => r.timings.duration < 2000,
+    });
+
+    sleep(0.1);
+}


### PR DESCRIPTION
### **`STEP 19`**

- 부하 테스트 대상 선정 및 목적, 시나리오 등의 계획을 세우고 이를 문서로 작성
- 적합한 테스트 스크립트를 작성하고 수행

> `NiceToHave` Docker 의 실행 옵션 (cpu, memory) 등을 조정하면서 애플리케이션을 실행하여 성능 테스트를 진행해보면서 적절한 배포 스펙 고려도 한번 진행해보세요!

## 학습 내용

<details>
<summary>부하 테스트 개요</summary>

## 개요

### 부하 테스트의 목적
- 시스템의 최대 처리 능력, 안정성 및 복구 능력을 확인하여 서비스 중단이나 성능 저하 예방
- 장애 원인 및 병목 구간 파악으로 향후 분산 환경 도입 및 최적화 계획 수립

### 테스트 유형
- **Load Test** : 일반 트래픽 상황에서 시스템 성능 확인  
- **Endurance Test** : 장시간 트래픽 지속 시 안정성 평가  
- **Stress Test** : 한계를 넘어서는 부하를 가해 시스템 임계점 확인  
- **Peak Test** : 단기간 최고 부하 상황에서 성능 및 복구 능력 검증  

### 주요 성능 지표
- **TPS(Transactions Per Second)** : 초당 처리 가능한 요청 수  
- **P95/P99 응답 시간** : 95%, 99% 요청이 완료되는 시간 측정  
- **CPU, Memory 사용률** : 과부하 발생 여부 및 시스템 자원 최적화 확인  
- **DB Connection Pool 사용률** : DB 연결 한계 도달 여부 파악  
- **에러율(HTTP 500, 429)** : 과부하 시 오류 발생 비율 확인  

### 고려 사항
- **SPOF 해결** : 서버 및 DB 이중화 또는 분산 처리 구조 도입 필요  
- **고가용성 확보** : 모니터링 체계 마련 및 장애 발생 대비 대응 방안 마련
- **예상 병목 현상** : DeadLock, 과도한 Lock 사용, Slow Query 등 성능 저하 요인 분석 및 대응 방안 마련

### 현재 환경과 문제점
- **현재 환경**  
  - 단일 서버와 단일 DB 환경에서 운영 중  
  - Redis 분산락, 카프카, MSA 전환 같은 분산 환경을 고려한 로직과 설계는 있지만 실제 환경은 모놀리식 아키텍처  
  - 단일 인스턴스 구성으로 하나의 로직 문제 발생 시 전체 시스템에 영향  
- **문제점**  
  - SPOF (Single Point of Failure) 문제 존재  
  - 장애 발생 시 복구 시간 지연 우려  
  - 단일 DB 환경에서 트랜잭션 집중에 따른 성능 저하 가능성  
 
- [조건 없는 조회 API → Redis 캐싱 개선 및 부하테스트](https://github.com/dhgudtmxhs/hhplus-ecommerce/pull/23)  
  - 조회 요청 트래픽이 많은 경우, Redis 캐싱으로 조회 성능 개선  
  - 포인트 충전과 같이 사용자별 INSERT/UPDATE가 필요한 로직은 캐싱 적용이 어려움
  - 트래픽이 몰리면 DB 락 경합 증가, 응답 지연 또는 트랜잭션 충돌로 인해 장애 발생 가능

</details>

<details>
<summary>부하 테스트 대상 선정 및 목적 시나리오 계획</summary>

## 포인트 충전 시나리오 

### domain service
![충전](https://github.com/user-attachments/assets/6796d12c-d05e-4fc1-b845-21e4499cff6a)  

### infra jpa repository
![락방지](https://github.com/user-attachments/assets/d4e48369-b329-4b51-a706-bfda7264bf88)  

- 포인트 충전은 현재 비관적 락(PESSIMISTIC_WRITE)을 적용하고 있으며, 데드락 발생 가능성은 낮다고 판단되지만, 쿼리 레벨에서 데드락 방지(Query Hint)를 추가 - 8db5c5c
- 다른 테이블과 함께 락이 걸리는 상황이 없고 락을 획득하는 순서가 일정하기 때문에 교차 락이 발생할 가능성이 매우 낮음
- 분산 환경을 고려하면 Redis 분산 락 적용도 가능하지만, 현재는 단일 환경이므로 성능 개선 효과가 없다고 판단하여 유지함  

### 목표 설정
- **포인트 충전** API를 대상으로 부하 테스트를 진행  
- 포인트 충전 로직은 **사용자별 쓰기(UPDATE)가 발생**하므로
  - 조회 트래픽 분산(Redis 캐싱) 방식으로 해결이 어려움  
  - 동시성 제어 및 DB 부하를 확인
- 이벤트 시, 단기간에 급증하는 요청을 안정적으로 처리할 수 있는지 확인
- **성능 목표**  
  - 응답 시간 : 평균 1초 이내, 최악의 경우 2초 이내 유지  
  - 에러율 : 1% 미만 (HTTP 500, 429 등 포함)  


### 시나리오 개요
- **포인트 충전 API** 요청을 발생시키되, 다음과 같은 트래픽 패턴을 가정  
  - **일반적인 트래픽 상황**  - 평소에는 충전 요청이 많지 않음  
  - **이벤트 트래픽 급증** - 특정 프로모션 발생 시, 사용자들이 대거 동시에 포인트 충전 요청을 보냄   
  - **트래픽 정상화**  - 이벤트 종료 후, 다시 평소 트래픽 수준으로 감소  

> 단기간에 요청량이 증가할 수 있으나, 포인트 충전 특성상 폭발적인 트래픽이 발생할 가능성은 낮아  
> 부하 테스트는 현실적인 사용량을 반영하여 적절한 수준으로 조정하여 진행


</details>

<details>
<summary>포인트 충전 부하테스트</summary>

## 부하 테스트

**포인트 충전 부하테스트를 위한 데이터 추가, script 생성** - 45510c7, 유저 1000명으로 수정 - 3e7ebfd

![충전테스트](https://github.com/user-attachments/assets/b48043c1-fae8-493c-bde8-7d3659483e99)

1. **stages 설정** 
   - 10초 동안 VU를 100명까지 늘리고, 이후 300 → 500 → 최대 1000명까지 단계적으로 증가  
   - 최대 부하(1000 VU)를 40초 유지한 뒤, 다시 100명 → 0명으로 감소  
   - **최대 1000명의 가상 사용자(VU)**가 동시에 API를 호출하는 상황을 테스트한다.

2. **userIds 배열을 사용하여, 요청 시 임의의 사용자 ID로 충전 요청**  
   - `const userIds = Array.from({ length: 1000 }, (_, i) => i + 1);`  
   - 1~1000번까지 1000명의 사용자 중 무작위로 선택

3. **PATCH /api/point/charge API 호출**  
   - `amount: 1000` 포인트를 충전하는 요청을 전송  
   - 테스트 대상 로직의 쓰기(UPDATE) 부하 및 DB 락 경합 등을 확인하기 위함

5. **check 구문에서 검증**  
   - 응답 상태코드 200(정상) 여부  
   - 응답 시간 2초 미만 유지 여부  
   - 이를 통해 각 요청의 성공 여부와 성능(지연 시간)을 모니터링 해볼 수 있다.

6. **sleep(0.1) 적용**  
   - 각 가상 사용자(VU)가 한 번 요청을 보낸 뒤 0.1초 휴식 후 다음 요청  
   - 너무 짧은 간격으로 동시에 요청이 몰리지 않도록 미세하게 분산 효과를 줌  

### 부하테스트 결과

![스크린샷 2025-02-27 오후 8 51 49](https://github.com/user-attachments/assets/9a6cff09-996c-4752-9691-6a2851395387)

### 포인트 충전 부하테스트 분석 - https://github.com/dhgudtmxhs/hhplus-ecommerce/pull/30

</details>

## PR 설명
feat: 포인트 충전 부하테스트를 위한 데이터 추가, script 생성 : 45510c7
refactor: 포인트 충전 데드락 방지를 위한 QueryHints 사용 : 8db5c5c
refactor: 테스트 유저 수 1000명으로 수정 : 3e7ebfd
chore: 잘못 넣은 point 테이블 fk 제약조건 삭제 : 42da38a

## 리뷰 포인트
**`STEP 19`** 에 맞게 과제를 잘 진행한걸까요?

## KPT

#### KEEP
과제 완료하고 제출하기

#### PROBLEM
설정 파일과 테스트 수행 절차를 잘 작성, 활용하지 못한 것 같음
계속 명령어를 입력하는데, 더 간단하게 할 수 있을듯

#### TRY
PROBLEM 공부하기

